### PR TITLE
Update schema.json re: rules categorisation

### DIFF
--- a/src/pages/RuleEditor/data/schema.json
+++ b/src/pages/RuleEditor/data/schema.json
@@ -310,6 +310,14 @@
         },
         "Group": {
             "type": "string"
+          },
+        "RuleScope": {
+            "type": "string",
+            "enum": [
+                "Publication and Jisc onward use",
+                "Interim Milestone 1, Criteria 2",
+                "Interim Milestone 2, Criteria 2"
+            ]
         },
         "FieldsToDisplay": {
             "type": "array",


### PR DESCRIPTION
Added in new RuleScope element with 3 label options: "Publication and Jisc onward use"
"Interim Milestone 1, Criteria 2"
"Interim Milestone 2, Criteria 2"

See SDA-3862 for details